### PR TITLE
Fix geo points sorting

### DIFF
--- a/src/geo.js
+++ b/src/geo.js
@@ -2,6 +2,7 @@ import urls from './urls'
 import totalRows from './utils/total-rows'
 import SQL from './utils/sql-builder'
 import { GEO_CATEGORY } from './utils/cache-tags'
+import _sortBy from 'lodash/sortBy'
 
 const toServerFence = ({ objectId, name, qualCriteria, type, nodes }) => ({
   name,
@@ -176,11 +177,7 @@ export default req => {
       const objectIds = data.map(point => point.objectId)
 
       return loadPointsByIds(appId, objectIds, params.includemetadata).then(points => {
-        const sortedPoints = []
-
-        points.forEach(point => {
-          sortedPoints[objectIds.indexOf(point.objectId)] = point
-        })
+        const sortedPoints = _sortBy(points, 'objectId')
 
         return { totalRows, data: sortedPoints }
       })


### PR DESCRIPTION
`objectIds` may contain duplicated ids, so usage it index as position in sorted array may lead to appearing undefined values in array. Simplest example:

```js
const objectIds = ['id1', 'id1', 'id1', 'id2'] // that's ok
...
const points = [{ objectId: 'id1' }, { objectId: 'id2' }]

points.forEach(point => { 
    sortedPoints[objectIds.indexOf(point.objectId)] = point

   // here we got first point at position 0, and in the second iteration 
   // we will got second point at position 3
   // objectIds.indexOf('id2') === 3
   // result - Array(point.id1, undefined, undefined, point.id2) 
})

```