### PR TITLE
Add method to reactivate billing subscription

### DIFF
--- a/src/billing.js
+++ b/src/billing.js
@@ -52,5 +52,9 @@ export default req => ({
   exchangeBBtoUSD(appId, bbAmount) {
     return req.billing.post(`${urls.billing(appId)}/bb/exchange`, bbAmount)
       .set({ 'Content-Type': 'application/json' })
-  }
+  },
+
+  reactivateSubscription(appId) {
+    return req.billing.put(`${urls.billing(appId)}/subscriptions/reactivate`)
+  },
 })


### PR DESCRIPTION
According to BKNDLSS-21915 ticket, if plan trial has been expired and user added CC after, it is not enough to switch plan - subscription reactivation should be called after it. Also, for the current plan for which trial is ended, if user wish to stay on it, plan switch is not required - only subscription reactivation is enough.