### PR TITLE
DATA-40 - Error "Could not parse request" appeared after adding column to the view from table with symbols in name

### DIFF
--- a/src/data-views.js
+++ b/src/data-views.js
@@ -69,6 +69,6 @@ export default req => ({
   loadSampleRecords(appId, table, query = {}) {
     const params = composeRequestParams(table, query)
 
-    return req.post(`${urls.data(appId)}/table-pre-view/${table.name}/find`, params)
+    return req.post(`${urls.data(appId)}/table-pre-view/${encodeURI(table.name)}/find`, params)
   }
 })

--- a/src/tables.js
+++ b/src/tables.js
@@ -18,7 +18,7 @@ const COLUMNS_URL_SUFFIX = {
 const isRelType = dataType => dataType === DataTypes.DATA_REF || dataType === DataTypes.GEO_REF
 
 const tableColumnsUrl = (appId, table) => urls.tableColumns(appId, table.name)
-const tableUrl = (appId, table) => `${urls.dataTables(appId)}/${table.name}`
+const tableUrl = (appId, table) => `${urls.dataTables(appId)}/${encodeURI(table.name)}`
 const removeRecordsUrl = (appId, table, removeAll) => `${tableUrl(appId, table)}/${removeAll ? 'all' : 'records'}`
 const assignedUserRoles = appId => `${urls.security(appId)}/assignedroles`
 


### PR DESCRIPTION
DATA-40 - Error "Could not parse request" appeared after adding column to the view from table with symbols in name